### PR TITLE
Add FastAPI skeleton for neighborhood pickup service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# neighbourhood-pickup-service
+# Neighbourhood Pickup Service
+
+This repository contains a minimal FastAPI application that models key pieces of a neighbourhood pickup service. Senders can build grocery carts and find nearby receivers who can deliver them.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8000 --app-dir src
+```
+
+## Running Tests
+
+```bash
+PYTHONPATH=src pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pytest

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,0 +1,1 @@
+# Package initialization

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,65 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List, Dict
+import math
+
+app = FastAPI()
+
+
+class CartItem(BaseModel):
+    name: str
+    quantity: int
+
+
+class Receiver(BaseModel):
+    id: str
+    lat: float
+    lon: float
+
+
+# In-memory stores
+carts: Dict[str, List[CartItem]] = {}
+receivers: Dict[str, Receiver] = {}
+
+
+@app.post("/senders/{sender_id}/cart/items", response_model=List[CartItem])
+def add_item(sender_id: str, item: CartItem):
+    """Add an item to a sender's cart."""
+    cart = carts.setdefault(sender_id, [])
+    cart.append(item)
+    return cart
+
+
+@app.get("/senders/{sender_id}/cart", response_model=List[CartItem])
+def get_cart(sender_id: str):
+    """Retrieve all items in a sender's cart."""
+    return carts.get(sender_id, [])
+
+
+@app.post("/receivers", response_model=Receiver)
+def register_receiver(receiver: Receiver):
+    """Register a receiver with their location."""
+    receivers[receiver.id] = receiver
+    return receiver
+
+
+def haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Calculate the great-circle distance between two points on Earth."""
+    R = 6371  # Earth radius in kilometers
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+    return R * c
+
+
+@app.get("/receivers/nearby", response_model=List[Receiver])
+def nearby_receivers(lat: float, lon: float, radius_km: float):
+    """List receivers within `radius_km` of the given coordinates."""
+    result = []
+    for receiver in receivers.values():
+        distance = haversine(lat, lon, receiver.lat, receiver.lon)
+        if distance <= radius_km:
+            result.append(receiver)
+    return result

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_add_and_get_cart():
+    response = client.post("/senders/s1/cart/items", json={"name": "apple", "quantity": 2})
+    assert response.status_code == 200
+    response = client.get("/senders/s1/cart")
+    assert response.json() == [{"name": "apple", "quantity": 2}]
+
+
+def test_nearby_receivers():
+    client.post("/receivers", json={"id": "r1", "lat": 10.0, "lon": 10.0})
+    client.post("/receivers", json={"id": "r2", "lat": 50.0, "lon": 50.0})
+    response = client.get("/receivers/nearby", params={"lat": 10.1, "lon": 10.1, "radius_km": 20})
+    data = {r["id"] for r in response.json()}
+    assert "r1" in data
+    assert "r2" not in data


### PR DESCRIPTION
## Summary
- scaffold FastAPI app with endpoints for cart items, receiver registration, and geolocation lookup
- add tests covering cart persistence and nearby receiver queries
- document setup and testing instructions

## Testing
- ⚠️ `pip install -r requirements.txt` (failed: Could not find a version that satisfies the requirement fastapi)
- ⚠️ `PYTHONPATH=src pytest` (failed: ModuleNotFoundError: No module named 'fastapi')

------
https://chatgpt.com/codex/tasks/task_e_68ab845f20c8832f8de3fbe3c0ea9ad6