### PR TITLE
Add HTML frontend for neighborhood pickup demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# neighbourhood-pickup-service
+# Neighbourhood Pickup Service
+
+This repository contains a minimal FastAPI application that models key pieces of a neighbourhood pickup service. Senders can build grocery carts and find nearby receivers who can deliver them.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8000 --app-dir src
+```
+
+Once running, open `http://localhost:8000/` in a browser to use the simple HTML frontend for adding cart items and browsing nearby receivers.
+
+## Running Tests
+
+```bash
+PYTHONPATH=src pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pytest

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,0 +1,1 @@
+# Package initialization

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,76 @@
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from typing import List, Dict
+from pathlib import Path
+import math
+
+app = FastAPI()
+
+static_dir = Path(__file__).parent / "static"
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+
+@app.get("/")
+def index():
+    return FileResponse(static_dir / "index.html")
+
+
+class CartItem(BaseModel):
+    name: str
+    quantity: int
+
+
+class Receiver(BaseModel):
+    id: str
+    lat: float
+    lon: float
+
+
+# In-memory stores
+carts: Dict[str, List[CartItem]] = {}
+receivers: Dict[str, Receiver] = {}
+
+
+@app.post("/senders/{sender_id}/cart/items", response_model=List[CartItem])
+def add_item(sender_id: str, item: CartItem):
+    """Add an item to a sender's cart."""
+    cart = carts.setdefault(sender_id, [])
+    cart.append(item)
+    return cart
+
+
+@app.get("/senders/{sender_id}/cart", response_model=List[CartItem])
+def get_cart(sender_id: str):
+    """Retrieve all items in a sender's cart."""
+    return carts.get(sender_id, [])
+
+
+@app.post("/receivers", response_model=Receiver)
+def register_receiver(receiver: Receiver):
+    """Register a receiver with their location."""
+    receivers[receiver.id] = receiver
+    return receiver
+
+
+def haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Calculate the great-circle distance between two points on Earth."""
+    R = 6371  # Earth radius in kilometers
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+    return R * c
+
+
+@app.get("/receivers/nearby", response_model=List[Receiver])
+def nearby_receivers(lat: float, lon: float, radius_km: float):
+    """List receivers within `radius_km` of the given coordinates."""
+    result = []
+    for receiver in receivers.values():
+        distance = haversine(lat, lon, receiver.lat, receiver.lon)
+        if distance <= radius_km:
+            result.append(receiver)
+    return result

--- a/src/app/static/index.html
+++ b/src/app/static/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Neighborhood Pickup</title>
+</head>
+<body>
+  <h1>Neighborhood Pickup Service</h1>
+
+  <section id="cart">
+    <h2>Cart</h2>
+    <input id="senderId" placeholder="Sender ID" value="s1">
+    <input id="itemName" placeholder="Item name">
+    <input id="itemQty" type="number" placeholder="Qty" value="1">
+    <button onclick="addItem()">Add Item</button>
+    <button onclick="loadCart()">Load Cart</button>
+    <ul id="cartItems"></ul>
+  </section>
+
+  <section id="receiver">
+    <h2>Register Receiver</h2>
+    <input id="receiverId" placeholder="Receiver ID">
+    <input id="receiverLat" placeholder="Lat">
+    <input id="receiverLon" placeholder="Lon">
+    <button onclick="registerReceiver()">Register</button>
+  </section>
+
+  <section id="nearby">
+    <h2>Nearby Receivers</h2>
+    <input id="queryLat" placeholder="Lat">
+    <input id="queryLon" placeholder="Lon">
+    <input id="queryRadius" placeholder="Radius km" value="5">
+    <button onclick="findNearby()">Find</button>
+    <ul id="nearbyList"></ul>
+  </section>
+
+  <script>
+    async function addItem() {
+      const sender = document.getElementById('senderId').value;
+      const name = document.getElementById('itemName').value;
+      const quantity = parseInt(document.getElementById('itemQty').value);
+      await fetch(`/senders/${sender}/cart/items`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({name, quantity})
+      });
+      loadCart();
+    }
+
+    async function loadCart() {
+      const sender = document.getElementById('senderId').value;
+      const resp = await fetch(`/senders/${sender}/cart`);
+      const items = await resp.json();
+      const ul = document.getElementById('cartItems');
+      ul.innerHTML = '';
+      items.forEach(item => {
+        const li = document.createElement('li');
+        li.textContent = `${item.quantity} x ${item.name}`;
+        ul.appendChild(li);
+      });
+    }
+
+    async function registerReceiver() {
+      const id = document.getElementById('receiverId').value;
+      const lat = parseFloat(document.getElementById('receiverLat').value);
+      const lon = parseFloat(document.getElementById('receiverLon').value);
+      await fetch('/receivers', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({id, lat, lon})
+      });
+    }
+
+    async function findNearby() {
+      const lat = parseFloat(document.getElementById('queryLat').value);
+      const lon = parseFloat(document.getElementById('queryLon').value);
+      const radius_km = parseFloat(document.getElementById('queryRadius').value);
+      const resp = await fetch(`/receivers/nearby?lat=${lat}&lon=${lon}&radius_km=${radius_km}`);
+      const receivers = await resp.json();
+      const ul = document.getElementById('nearbyList');
+      ul.innerHTML = '';
+      receivers.forEach(r => {
+        const li = document.createElement('li');
+        li.textContent = `${r.id} (${r.lat}, ${r.lon})`;
+        ul.appendChild(li);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_add_and_get_cart():
+    response = client.post("/senders/s1/cart/items", json={"name": "apple", "quantity": 2})
+    assert response.status_code == 200
+    response = client.get("/senders/s1/cart")
+    assert response.json() == [{"name": "apple", "quantity": 2}]
+
+
+def test_nearby_receivers():
+    client.post("/receivers", json={"id": "r1", "lat": 10.0, "lon": 10.0})
+    client.post("/receivers", json={"id": "r2", "lat": 50.0, "lon": 50.0})
+    response = client.get("/receivers/nearby", params={"lat": 10.1, "lon": 10.1, "radius_km": 20})
+    data = {r["id"] for r in response.json()}
+    assert "r1" in data
+    assert "r2" not in data
+
+
+def test_index_page_served():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Neighborhood Pickup" in response.text


### PR DESCRIPTION
## Summary
- serve static index page and expose it via root FastAPI route
- add simple JavaScript frontend to add cart items and find nearby receivers
- document how to access the frontend and test its availability

## Testing
- ⚠️ `pip install -r requirements.txt` (Could not find a version that satisfies the requirement fastapi)
- ⚠️ `PYTHONPATH=src pytest` (ModuleNotFoundError: No module named 'fastapi')

------
https://chatgpt.com/codex/tasks/task_e_68ab845f20c8832f8de3fbe3c0ea9ad6